### PR TITLE
update mplus_expand_names function

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -98,7 +98,7 @@ has_data <- function(x){
 #' Mplus syntax file.
 #' @return Character vector of names.
 #' @examples
-#' mplus_expand_names("test1-test12", "testa_testb")
+#' mplus_expand_names("test1-test12", "testa-testb")
 #' @rdname mplus_expand_names
 #' @keywords mplus utilities
 #' @export


### PR DESCRIPTION
update mplus_expand_names function, since Mplus can expand name ends with letters. Now mplus_expand_names function can expand variable name like testa-testd, or test_a-test_d.
