### PR TITLE
update BLRT method

### DIFF
--- a/R/mixture_summaries.R
+++ b/R/mixture_summaries.R
@@ -253,33 +253,53 @@ icl_default <- function(post_prob, BIC){
 #' BLRT(res, replications = 4)      
 #' }
 #' @export
-BLRT <- function(x, ...){
+BLRT <- function(x, ...,
+                 all = FALSE,
+                 replications = 10,
+                 previousRun = NULL,
+                 checkHess = FALSE){
+  garbage_arguments <- list(...)
+  if (length(garbage_arguments) > 0) {
+    stop("BLRT does not accept values for the '...' argument")
+  }
+
   UseMethod("BLRT", x)
 }
 
-BLRT.mixture_list <- function(x, ...){
+
+
+#' @method BLRT mixture_list
+#' @export
+BLRT.mixture_list <- function(x,...,
+                              all = FALSE,
+                              replications = 10,
+                              previousRun = NULL,
+                              checkHess = FALSE){
+
   if(length(x) > 1){
+
     out <- mapply(function(k, km1){
       tryCatch({
-        unlist(mxCompare(k, km1, boot = TRUE, ...)[2, c("diffLL", "diffdf", "p")])
+        unlist(mxCompare(k,
+                         km1, ...,
+                         boot = TRUE,
+                         all = all,
+                         replications = replications,
+                         previousRun = previousRun,
+                         checkHess = checkHess)[2, c("diffLL", "diffdf", "p")])
       },
       error = function(e){
         c("diffLL" = NA, "diffdf" = NA, "p" = NA)
       })
     }, k = x[-1], km1 = x[-length(x)])
-    res <- rbind(data.frame(diffLL = NA, diffdf = NA, p = NA), t(out))
-    if(all(is.na(res))) warning("Please check BLRT function, it should include specific argument name. e.g., BLRT(res, replications = 4), not BLRT(res, 4)")
+    rbind(data.frame(diffLL = NA, diffdf = NA, p = NA),
+          t(out))
   } else {
-    res <- data.frame(diffLL = NA, diffdf = NA, p = NA)
+    data.frame(diffLL = NA, diffdf = NA, p = NA)
   }
-  return(res)
 }
 
 
 #' @method BLRT list
 #' @export
 BLRT.list <- BLRT.mixture_list
-
-#' @method BLRT MxRAMModel
-#' @export
-BLRT.MxRAMModel <- BLRT.mixture_list


### PR DESCRIPTION
1. define the BLRT method for the MxRAMModel class to cope with Error in UseMethod("BLRT", x) : no applicable method for 'BLRT' applied to an object of class "c('MxRAMModel', 'MxModel')" 
```r
library(tidySEM)
#> Loading required package: OpenMx
# only 1 class 
 res <- mx_mixture(
  model = "x ~ m{C}*1
           x ~~ v{C}*x",
  classes = 1,
  data = df
)
#> Running mix1 with 2 parameters

BLRT(res, replications = 4)
#> Error in UseMethod("BLRT", x): no applicable method for 'BLRT' applied to an object of class "c('MxRAMModel', 'MxModel')"
```
2. adding a warning message when the user forgets to specify the argument name.
```r
library(tidySEM)
#> Loading required package: OpenMx
df <- iris[, 1, drop = FALSE]
names(df) <- "x"
res <- mx_mixture(model = "x ~ m{C}*1
                           x ~~ v{C}*x", 
                  class = 1:2, 
                  data = df
                  )
BLRT(res, 4)
#> Warning in BLRT.mixture_list(res, 4): Please check BLRT function, it should
#> include specific argument name. e.g., BLRT(res, replications = 4), not BLRT(res,
#> 4)
#>   diffLL diffdf  p
#> 1     NA     NA NA
#> 2     NA     NA NA
```