### PR TITLE
Update mx_mixture.R: fix Error in FUN(X[[i]], ...) : object 'isfac' not found

### DIFF
--- a/R/mx_mixture.R
+++ b/R/mx_mixture.R
@@ -541,6 +541,7 @@ mixture_starts <- function(model,
   strts <- lapply(1:classes, function(i){
     thissub <- names(model@submodels)[i]
     data_split <- data[splits == i, , drop = FALSE]
+    isfac <- sapply(data_split, inherits, what = "factor")
     if(any(isfac)){
       tabfreq <- lapply(data_split[which(isfac)], table)
       if(any(unlist(tabfreq) == 0)){


### PR DESCRIPTION
A line of code was missing in the function `mixture_starts` which leads to:
`Error in FUN(X[[i]], ...) : object 'isfac' not found`

The error occurs when using the splits argument in a call to `mx_mixture` or `mx_growth_mixture`.

The line of code that needs to be added can look like:
```r
isfac <- sapply(data_split, inherits, what = "factor")
```

The line can also be inserted at line 540 (outside the loop) since data columns are constant.

A sidenote, per the documentation of `mixture_starts`, it is possible to create a model and in step 2 set the start values.
However, the initial model creation via `mx_mixture` also tries to set the start values. If this fails, because of missing data or other reasons, there seems to be no way of setting the starting values manually with the `splits` argument to `mx_mixture`.