### PR TITLE
Fix typo in vignette (#82)

### DIFF
--- a/docs/articles/Generating_syntax.html
+++ b/docs/articles/Generating_syntax.html
@@ -270,8 +270,8 @@ using lavaan:</p>
 <span><span class="co">#&gt;   Test statistic                                85.306</span></span>
 <span><span class="co">#&gt;   Degrees of freedom                                24</span></span>
 <span><span class="co">#&gt;   P-value (Chi-square)                           0.000</span></span></code></pre>
-<p>The same model can be estimated in ‘Mplus’ through the R-package
-<code>MplusAutomation</code>. This requires ‘Mplus’ to be installed.</p>
+<p>The same model can be estimated with ‘OpenMx’ through the R-package
+<code>OpenMx</code>.</p>
 <div class="sourceCode" id="cb8"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span><span class="va">model</span> <span class="op">|&gt;</span></span>
 <span>  <span class="fu"><a href="../reference/estimate_mx.html">estimate_mx</a></span><span class="op">(</span><span class="op">)</span></span></code></pre></div>

--- a/vignettes/Generating_syntax.Rmd
+++ b/vignettes/Generating_syntax.Rmd
@@ -107,7 +107,7 @@ model |>
 estimate_lavaan(model)
 ```
 
-The same model can be estimated in 'Mplus' through the R-package `MplusAutomation`. This requires 'Mplus' to be installed.
+The same model can be estimated with 'OpenMx' through the R-package `OpenMx`.
 
 ```{r include=FALSE}
 estimate_mx(model) -> res_mx


### PR DESCRIPTION
This fixes the typo both in source and rendered pkgdown vignette.