### PR TITLE
Updated skew_kurtosis function (Fixes issue(s) #127)

### DIFF
--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -190,13 +190,13 @@ skew_kurtosis.matrix <-
 #' @method skew_kurtosis numeric
 #' @export
 skew_kurtosis.numeric <-
-  function (x, verbose = FALSE, se = FALSE, pearson = FALSE, corrected = TRUE, ...) 
+  function (x, verbose = FALSE, se = FALSE, pearson = FALSE, corrected = TRUE, ...)
 {
   x <- x[!is.na(x)]
   n <- length(x)
   out <- tryCatch({
     if (n > 3) {
-      if (n > 5000 & verbose) 
+      if (n > 5000 & verbose)
         message("Sample size > 5000; skew and kurtosis will likely be significant.")
       skew <- (sum((x - mean(x))^3)/n)/(sum((x - mean(x))^2)/n)^(3/2)
       skew_se <- sqrt((6 * (n - 2)) / ((n + 1) * (n + 3)))
@@ -204,10 +204,9 @@ skew_kurtosis.numeric <-
       if (corrected) {
         skew <- sqrt(n * (n - 1)) / (n - 2) * skew
         skew_se <- sqrt(skew_se^2 * (n * (n - 1) / (n - 2)^2))
-        print(sqrt((6 * n * (n - 1))/((n - 2) * (n + 1) * (n + 3))))
         skew_2se <- skew/(2 * skew_se)
       }
-      
+
       kurt_pearson <- n * (sum((x - mean(x))^4)/(sum((x - mean(x))^2)^2))
       kurt_excess <- kurt_pearson - 3
       kurt_se <- sqrt((24 * n * (n - 2) * (n - 3)) / (((n + 1)^2) * (n + 3) * (n + 5)))
@@ -226,7 +225,7 @@ skew_kurtosis.numeric <-
   }, error = function(e) {
     rep(NA, 7)
   })
-  names(out) <- c("skew", "skew_se", "skew_2se", "kurt_pearson", "kurt_excess", "kurt_se", 
+  names(out) <- c("skew", "skew_se", "skew_2se", "kurt_pearson", "kurt_excess", "kurt_se",
                   "kurt_2se")
   if (!se) {
     keep <- c("skew", "skew_2se", "kurt_excess", "kurt_2se")
@@ -237,7 +236,7 @@ skew_kurtosis.numeric <-
   if (pearson) {
     keep <- append(keep, "kurt_pearson", after = ifelse(se, 3, 2))
   }
-  
+
   return(out[keep])
 }
 
@@ -246,7 +245,7 @@ skew_kurtosis.numeric <-
 skew_kurtosis.default <-
   function(x, verbose = FALSE, se = FALSE, ...) {
     out <- rep(NA, 7)
-    names(out) <- c("skew", "skew_se", "skew_2se", "kurt_pearson", "kurt_excess", "kurt_se", 
+    names(out) <- c("skew", "skew_se", "skew_2se", "kurt_pearson", "kurt_excess", "kurt_se",
                   "kurt_2se")
   if (!se) {
     keep <- c("skew", "skew_2se", "kurt_excess", "kurt_2se")
@@ -257,7 +256,7 @@ skew_kurtosis.default <-
   if (pearson) {
     keep <- append(keep, "kurt_pearson", after = ifelse(se, 3, 2))
   }
-  
+
   return(out[keep])
   }
 

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -184,7 +184,7 @@ skew_kurtosis.data.frame <-
 #' @export
 skew_kurtosis.matrix <-
   function(x, verbose = FALSE, se = FALSE, pearson = FALSE, corrected = TRUE, ...) {
-    t(sapply(x, 2, skew_kurtosis, verbose = verbose, se = se, pearson = pearson, corrected = corrected, ...))
+    t(apply(x, 2, skew_kurtosis, verbose = verbose, se = se, pearson = pearson, corrected = corrected, ...))
   }
 
 #' @method skew_kurtosis numeric

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -243,7 +243,7 @@ skew_kurtosis.numeric <-
 #' @method skew_kurtosis default
 #' @export
 skew_kurtosis.default <-
-  function(x, verbose = FALSE, se = FALSE, ...) {
+  function(x, verbose = FALSE, se = FALSE, pearson = FALSE, corrected = TRUE, ...) {
     out <- rep(NA, 7)
     names(out) <- c("skew", "skew_se", "skew_2se", "kurt_pearson", "kurt_excess", "kurt_se",
                   "kurt_2se")

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -165,85 +165,96 @@ var_cat <- function(x) {
 #' skew_kurtosis(datasets::anscombe)
 #' @rdname skew_kurtosis
 #' @export
-skew_kurtosis <- function(x, verbose = FALSE, se = FALSE, ...) {
+skew_kurtosis <- function(x, verbose = FALSE, se = FALSE, pearson = FALSE, corrected = TRUE, ...) {
   UseMethod("skew_kurtosis", x)
-}
-
-#' @method skew_kurtosis matrix
-#' @export
-skew_kurtosis.matrix <-
-  function(x, verbose = FALSE, se = FALSE, ...) {
-    Args <- as.list(match.call()[-1])
-    Args$x <- data.frame(x)
-    do.call(skew_kurtosis, Args)
 }
 
 #' @method skew_kurtosis data.frame
 #' @export
 skew_kurtosis.data.frame <-
-  function(x, verbose = FALSE, se = FALSE, ...) {
-    t(sapply(x, skew_kurtosis))
+  function(x, verbose = FALSE, se = FALSE, pearson = FALSE, corrected = TRUE, ...) {
+    t(sapply(x, skew_kurtosis, verbose = verbose, se = se, pearson = pearson, corrected = corrected, ...))
   }
 
 #' @method skew_kurtosis matrix
 #' @export
 skew_kurtosis.matrix <-
-  function(x, verbose = FALSE, se = FALSE, ...) {
-    t(apply(x, 2, skew_kurtosis))
+  function(x, verbose = FALSE, se = FALSE, pearson = FALSE, corrected = TRUE, ...) {
+    t(sapply(x, 2, skew_kurtosis, verbose = verbose, se = se, pearson = pearson, corrected = corrected, ...))
   }
 
 #' @method skew_kurtosis numeric
 #' @export
 skew_kurtosis.numeric <-
-  function(x, verbose = FALSE, se = FALSE, ...) {
-    x <- x[!is.na(x)]
-    n <- length(x)
-    out <- tryCatch({
-      if (n > 3) {
-        if (n > 5000 &
-            verbose)
-          message("Sample size > 5000; skew and kurtosis will likely be significant.")
-        skew <- (sum((x - mean(x))^3)/n)/(sum((x - mean(x))^2)/n)^(3/2)
-        skew_se <- sqrt((6 * n * (n - 1)) / ((n - 2) * (n + 1) * (n + 3)))
-        skew_2se <- skew / (2 * skew_se)
-        kurt <- n * (sum((x - mean(x)) ^ 4) / (sum((x - mean(x))^2)^2))
-        kurt_se <- sqrt(24 * n * ((n - 1) ^ 2) / (n - 3) / (n - 2) / (n + 3) /
-                          (n + 5))
-
-        kurt_2se <- kurt / (2 * kurt_se)
-        c(skew,
-          skew_se,
-          skew_2se,
-          kurt,
-          kurt_se,
-          kurt_2se
-        )
-      } else {
-        stop()
+  function (x, verbose = FALSE, se = FALSE, pearson = FALSE, corrected = TRUE, ...) 
+{
+  x <- x[!is.na(x)]
+  n <- length(x)
+  out <- tryCatch({
+    if (n > 3) {
+      if (n > 5000 & verbose) 
+        message("Sample size > 5000; skew and kurtosis will likely be significant.")
+      skew <- (sum((x - mean(x))^3)/n)/(sum((x - mean(x))^2)/n)^(3/2)
+      skew_se <- sqrt((6 * (n - 2)) / ((n + 1) * (n + 3)))
+      skew_2se <- skew/(2 * skew_se)
+      if (corrected) {
+        skew <- sqrt(n * (n - 1)) / (n - 2) * skew
+        skew_se <- sqrt(skew_se^2 * (n * (n - 1) / (n - 2)^2))
+        print(sqrt((6 * n * (n - 1))/((n - 2) * (n + 1) * (n + 3))))
+        skew_2se <- skew/(2 * skew_se)
       }
-    }, error = function(e){ rep(NA, 6) })
-
-    names(out) <-
-      c("skew", "skew_se", "skew_2se", "kurt", "kurt_se", "kurt_2se")
-    if (se) {
-      return(out)
-    } else {
-      return(out[c(1, 3, 4, 6)])
+      
+      kurt_pearson <- n * (sum((x - mean(x))^4)/(sum((x - mean(x))^2)^2))
+      kurt_excess <- kurt_pearson - 3
+      kurt_se <- sqrt((24 * n * (n - 2) * (n - 3)) / (((n + 1)^2) * (n + 3) * (n + 5)))
+      kurt_2se <- kurt_excess/(2 * kurt_se)
+      if (corrected) {
+        kurt_excess <- ((n - 1) / ((n - 2) * (n - 3))) * ((n + 1) * kurt_excess + 6)
+        kurt_pearson <- kurt_excess + 3
+        kurt_se <- sqrt(kurt_se^2 * (((n - 1) * (n + 1)) / ((n - 2) * (n - 3)))^2)
+        kurt_2se <- kurt_excess/(2 * kurt_se)
+      }
+      c(skew, skew_se, skew_2se, kurt_pearson, kurt_excess, kurt_se, kurt_2se)
     }
+    else {
+      stop()
+    }
+  }, error = function(e) {
+    rep(NA, 7)
+  })
+  names(out) <- c("skew", "skew_se", "skew_2se", "kurt_pearson", "kurt_excess", "kurt_se", 
+                  "kurt_2se")
+  if (!se) {
+    keep <- c("skew", "skew_2se", "kurt_excess", "kurt_2se")
+  } else {
+    keep <- c("skew", "skew_se", "skew_2se",
+              "kurt_excess", "kurt_se", "kurt_2se")
   }
+  if (pearson) {
+    keep <- append(keep, "kurt_pearson", after = ifelse(se, 3, 2))
+  }
+  
+  return(out[keep])
+}
 
 #' @method skew_kurtosis default
 #' @export
 skew_kurtosis.default <-
   function(x, verbose = FALSE, se = FALSE, ...) {
-    out <- rep(NA, 6)
-    names(out) <-
-      c("skew", "skew_se", "skew_2se", "kurt", "kurt_se", "kurt_2se")
-    if (se) {
-      return(out)
-    } else {
-      return(out[c(1, 3, 4, 6)])
-    }
+    out <- rep(NA, 7)
+    names(out) <- c("skew", "skew_se", "skew_2se", "kurt_pearson", "kurt_excess", "kurt_se", 
+                  "kurt_2se")
+  if (!se) {
+    keep <- c("skew", "skew_2se", "kurt_excess", "kurt_2se")
+  } else {
+    keep <- c("skew", "skew_se", "skew_2se",
+              "kurt_excess", "kurt_se", "kurt_2se")
+  }
+  if (pearson) {
+    keep <- append(keep, "kurt_pearson", after = ifelse(se, 3, 2))
+  }
+  
+  return(out[keep])
   }
 
 

--- a/R/descriptives.R
+++ b/R/descriptives.R
@@ -158,12 +158,16 @@ var_cat <- function(x) {
 #' @param x An object for which a method exists.
 #' @param verbose Logical. Whether or not to print messages to the console,
 #' Default: FALSE
-#' @param se Whether or not to return the standard errors, Default: FALSE
+#' @param se Logical. Whether or not to return the standard errors, Default: FALSE
+#' @param pearson Logical. Whether or not to return the Pearson's kurtosis alongside excess kurtosis, Default: FALSE
+#' @param corrected Logical. Whether or not to correct for bias in skew and kurtosis (Joanes & Gill, 1998). Corrects both the estimates and their standard errors. Default: TRUE
 #' @param ... Additional arguments to pass to and from functions.
 #' @return A \code{matrix} of skew and kurtosis statistics for \code{x}.
 #' @examples
 #' skew_kurtosis(datasets::anscombe)
 #' @rdname skew_kurtosis
+#' @references
+#' Joanes, D. N. & Gill, C. A. (1998). Comparing measures of sample skewness and kurtosis. \emph{Journal Of The Royal Statistical Society: Series D (The Statistician)}, \emph{47}(1), 183–189. \url{https://doi.org/10.1111/1467-9884.00122}
 #' @export
 skew_kurtosis <- function(x, verbose = FALSE, se = FALSE, pearson = FALSE, corrected = TRUE, ...) {
   UseMethod("skew_kurtosis", x)

--- a/man/skew_kurtosis.Rd
+++ b/man/skew_kurtosis.Rd
@@ -4,7 +4,14 @@
 \alias{skew_kurtosis}
 \title{Calculate skew and kurtosis}
 \usage{
-skew_kurtosis(x, verbose = FALSE, se = FALSE, ...)
+skew_kurtosis(
+  x,
+  verbose = FALSE,
+  se = FALSE,
+  pearson = FALSE,
+  corrected = TRUE,
+  ...
+)
 }
 \arguments{
 \item{x}{An object for which a method exists.}
@@ -12,7 +19,11 @@ skew_kurtosis(x, verbose = FALSE, se = FALSE, ...)
 \item{verbose}{Logical. Whether or not to print messages to the console,
 Default: FALSE}
 
-\item{se}{Whether or not to return the standard errors, Default: FALSE}
+\item{se}{Logical. Whether or not to return the standard errors, Default: FALSE}
+
+\item{pearson}{Logical. Whether or not to return the Pearson's kurtosis alongside excess kurtosis, Default: FALSE}
+
+\item{corrected}{Logical. Whether or not to correct for bias in skew and kurtosis (Joanes & Gill, 1998). Corrects both the estimates and their standard errors. Default: TRUE}
 
 \item{...}{Additional arguments to pass to and from functions.}
 }
@@ -27,4 +38,7 @@ large sample sizes, significant skew/kurtosis is common.
 }
 \examples{
 skew_kurtosis(datasets::anscombe)
+}
+\references{
+Joanes, D. N. & Gill, C. A. (1998). Comparing measures of sample skewness and kurtosis. \emph{Journal Of The Royal Statistical Society: Series D (The Statistician)}, \emph{47}(1), 183–189. \url{https://doi.org/10.1111/1467-9884.00122}
 }

--- a/news.md
+++ b/news.md
@@ -6,6 +6,12 @@
 * Export mx_deviances()
 * Fix bug in get_edges() and get_nodes() for multigroup lavaan models with user-
   defined quantities (`:=`), issue #109.
+* Add the option to output Pearson's kurtosis alongside excess kurtosis, and modify
+  the formula for significance to refer to excess kurtosis; see issue #127.
+* Add corrected skewness and kurtosis values, implement option to output uncorrected
+  values; see issue #127.
+* Modify the skew_kurtosis methods for matrices and data frames: Add new arguments,
+  make sure arguments are passed down, and remove doubled .matrix function. See issue #127.
 
 # tidySEM 0.2.10
 

--- a/news.md
+++ b/news.md
@@ -6,10 +6,10 @@
 * Export mx_deviances()
 * Fix bug in get_edges() and get_nodes() for multigroup lavaan models with user-
   defined quantities (`:=`), issue #109.
-* Add the option to output Pearson's kurtosis alongside excess kurtosis, and modify
-  the formula for significance to refer to excess kurtosis; see issue #127.
-* Add corrected skewness and kurtosis values, implement option to output uncorrected
-  values; see issue #127.
+* skew_kurtosis: Add the option to output Pearson's kurtosis alongside excess kurtosis,
+  and modify the formula for significance to refer to excess kurtosis; see issue #127.
+* skew_kurtosis: Update to corrected skewness and kurtosis values, implement option to
+  output uncorrected values instead; see issue #127.
 * Modify the skew_kurtosis methods for matrices and data frames: Add new arguments,
   make sure arguments are passed down, and remove doubled .matrix function. See issue #127.
 


### PR DESCRIPTION
# Description
The function `skew_kurtosis` was modified to address several issues:
- Pearson's kurtosis was calculated, but the formula that was used to indicate significance needs a centered value such as excess kurtosis.
- Standard errors were calculated based on formulas for corrected skewness and kurtosis, while uncorrected values were provided for both.
- When data frames and matrices were used with the function, arguments were ignored.

# Changes
To address them, the following chances have been made:
- Added the logical argument `pearson`. By default (`= FALSE`), only excess kurtosis is provided, together with the significance indicator. When set to `TRUE`, Pearson's kurtosis is added to the output.
- Added the logical argument `corrected`. By default (`= TRUE`), skewness, kurtosis and their standard errors are corrected for bias, which is especially noticeable in small samples. When set to `FALSE`, uncorrected values are provided.
- The S3 methods for data frames and matrices were fixed, an unnecessary matrix method was removed, and all functions were updated to include the new arguments.

Furthermore, both the documentation page for `skew_kurtosis` and the news file were updated.